### PR TITLE
Fix trailing comma in pretrained_model_name_or_path help string in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ def parse_args(input_args=None):
         type=str,
         default=None,
         help=(
-            "Path or name of a pretrained checkpoint to load the model from.\n",
+            "Path or name of a pretrained checkpoint to load the model from.\n"
             "   This can be either:\n"
             "   - a string, the *model id* of a pretrained model hosted inside a model repo on huggingface.co, e.g., `robotics-diffusion-transformer/rdt-1b`,\n"
             "   - a path to a *directory* containing model weights saved using [`~RDTRunner.save_pretrained`] method, e.g., `./my_model_directory/`.\n"


### PR DESCRIPTION
This PR removes a trailing comma in the pretrained_model_name_or_path argument's help in main.py which causes an error when running the main.py script.