### PR TITLE
fix(cross-attn): use positional args for SDPA to unblock DS FLOPs profiler

### DIFF
--- a/models/rdt/blocks.py
+++ b/models/rdt/blocks.py
@@ -115,9 +115,9 @@ class CrossAttention(nn.Module):
         
         if self.fused_attn:
             x = F.scaled_dot_product_attention(
-                query=q,
-                key=k,
-                value=v,
+                q,
+                k,
+                v,
                 dropout_p=self.attn_drop.p if self.training else 0.,
                 attn_mask=mask
             )


### PR DESCRIPTION
When profiling with DeepSpeed FLOPs profiler, F.scaled_dot_product_attention called with keyword args (query=, key=, value=) isn’t traced correctly.

Using kwargs raises:
`TypeError: _attn_flops_compute() missing 3 required positional arguments: 'q', 'k', and 'v'`

To fix it:
In models/rdt/blocks.py::CrossAttention.forward, pass q, k, v as positional arguments